### PR TITLE
Fixes and updates for frugal_watchdog bash script

### DIFF
--- a/frugal_watchdog
+++ b/frugal_watchdog
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 serial=/dev/ttyUSB0
+timeout=1
 
 if [ "$1" == "-h" ] ; then
     cat 1>&2 <<EOF
@@ -27,6 +28,9 @@ fi
 exec 3<> "$serial" || exit $?
 stty 2400 hupcl igncr < "$serial" || exit $?
 
+# Discard any data that might be in the serial buffer.
+read -t 0.1 <&3
+
 if [ -z "$1" ] || [ "$1" = "reset" ] || [ "$1" = "start" ] \
    || [ "$1" = "test" ] || [ "$1" = "repair" ] ; then
     printf "reset\r%s\r" "$(date +%s)" >&3
@@ -34,9 +38,9 @@ elif [ "$1" = "timeout" ] && [ -n "$2" ] ; then
     printf "timeout\r%s\r" "$2" >&3
 elif [ "$1" = "status" ] ; then
     printf "status\r" >&3
-    read line <&3
+    read -t "$timeout" line <&3 || exit $?
     printf "Elapsed: %s s\n" $line
-    read line <&3
+    read -t "$timeout" line <&3 || exit $?
     d=$(date -d @"$line")
     printf "Watchdog was last triggered at: %s\n" "$d"
 elif [ "$1" = "stop" ] ; then

--- a/frugal_watchdog
+++ b/frugal_watchdog
@@ -24,23 +24,23 @@ with the watchdog(8) daemon. This script can be dropped in the
 EOF
 fi
 
-stty 2400 igncr < "$serial" || exit $?
+exec 3<> "$serial" || exit $?
+stty 2400 hupcl igncr < "$serial" || exit $?
 
 if [ -z "$1" ] || [ "$1" = "reset" ] || [ "$1" = "start" ] \
    || [ "$1" = "test" ] || [ "$1" = "repair" ] ; then
-    printf "reset\r%s\r" "$(date +%s)" > "$serial"
+    printf "reset\r%s\r" "$(date +%s)" >&3
 elif [ "$1" = "timeout" ] && [ -n "$2" ] ; then
-    printf "timeout\r%s\r" "$2" > "$serial"
+    printf "timeout\r%s\r" "$2" >&3
 elif [ "$1" = "status" ] ; then
-    exec 3< "$serial"
-    printf "status\r" > "$serial"
+    printf "status\r" >&3
     read line <&3
     printf "Elapsed: %s s\n" $line
     read line <&3
     d=$(date -d @"$line")
     printf "Watchdog was last triggered at: %s\n" "$d"
 elif [ "$1" = "stop" ] ; then
-    printf "stop\r" > "$serial"
+    printf "stop\r" >&3
 elif [ "$1" = "clearmem" ] ; then
-    printf "clearmem\r" > "$serial"
+    printf "clearmem\r" >&3
 fi

--- a/frugal_watchdog
+++ b/frugal_watchdog
@@ -23,6 +23,7 @@ Parameters 'test' and 'repair' are aliased to 'reset' for compatibility
 with the watchdog(8) daemon. This script can be dropped in the
 /etc/watchdog.d/ directory.
 EOF
+exit
 fi
 
 exec 3<> "$serial" || exit $?


### PR DESCRIPTION
The supplied bash script frugal_watchdog does not work for me. Testing manually with picocom has shown that I have to set the 'hupcl' flag with stty, otherwise the 'status' command just hangs indefinitely. In addition, the 'hupcl' flag seems to be reset when closing the file descriptor, so trying to set it with stty and _only then_ opening the port and reading from it does not work. I have changed the bash script to open the port _once_ and use the file descriptor from then on.

The original failure to chooch also revealed a dire need for read timeouts, so I have added that as well.

An additional trivial commit prevents the script from touching the port if only help is being displayed.
